### PR TITLE
[publish] Adds a publish config to publish publicly

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "publishConfig": {
+    "@addepar:registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
Currently if we publish we'll end up publishing to our mirror repository,
which is not what we want for our open source projects. This allows us to
publish to NPM even if the mirror repo is set