### PR TITLE
[bugfix] Fixes table styles

### DIFF
--- a/styles/components/table/_core.scss
+++ b/styles/components/table/_core.scss
@@ -146,15 +146,17 @@
     padding: $et-table-cell-padding;
   }
 
-  tr.is-selectable {
-    cursor: pointer;
-
+  tr {
     &.is-selected {
       background: $et-selectable-row-selected-background;
     }
 
-    &:hover {
-      background: $et-selectable-row-hover-background;
+    &.is-selectable {
+      cursor: pointer;
+
+      &:hover {
+        background: $et-selectable-row-hover-background;
+      }
     }
   }
 }

--- a/styles/elements/table/_core.scss
+++ b/styles/elements/table/_core.scss
@@ -44,6 +44,7 @@
 
   td {
     padding: $table-cell-padding;
+    background: $table-cell-background;
   }
 
   thead {

--- a/styles/elements/table/_variables.scss
+++ b/styles/elements/table/_variables.scss
@@ -5,7 +5,7 @@ $table-font-size: $font-size-base;
 $table-text-color: $text-dark;
 
 $table-border-style: $border-item-style;
-$table-header-footer-background: $background-white;
+$table-cell-background: $background-white;
 
 $table-cell-padding: $spacing-small;
 $table-cell-overflow: hidden;


### PR DESCRIPTION
Fixes two issues with table styles:

1. Table cells did not have an explicit background color. This broke,
particularly when using fixed table columns.
2. Table rows could be selected, even if they were not "selectable"
(e.g. they can be selected via checkbox)