### PR TITLE
Create granular files for button types for easier pick and choosing

### DIFF
--- a/styles/onyx/elements/inputs/button/_core.scss
+++ b/styles/onyx/elements/inputs/button/_core.scss
@@ -13,81 +13,8 @@
 // Core Button CSS
 // -----------------------------------------------------------------------------
 
-// Core Button
-// -----------------------------------------------------------------------------
-//
+@import 'placeholders';
 
-// Button placeholder used to create button types
-%button {
-  @include reset-button();
-  user-select: none;
-  touch-action: manipulation;
-  cursor: pointer;
-
-  // Text formatting
-  color: $button-base-color;
-  font-family: $button-font-family;
-  font-size: $button-font-size;
-  font-weight: $button-font-weight;
-  text-align: center;
-  white-space: nowrap;
-
-  // Buttons now have a specific height for enforced uniformity
-  height: $button-height;
-  vertical-align: middle;
-  min-width: $button-min-width;
-  padding-left: $button-spacing-horizontal;
-  padding-right: $button-spacing-horizontal;
-
-  // Border placeholder maintains consistent spacing around all buttons with or without borders
-  border: $button-border-width solid transparent;
-  border-radius: $button-border-radius;
-
-  transition: background-color $button-transition-speed ease-in-out, border-color $button-transition-speed ease-in-out;
-
-  // Hover state
-  &:hover {
-    color: ice-adjust-color($button-base-color, $button-hover-color-inc);
-  }
-
-  // Active/Pressed state
-  &:active,
-  &.is-active,
-  &.active, // TODO: see if we can get ember to use is-active instead
-  .open &.dropdown-toggle { // TODO: remove dropdown-toggle after dropdown refactor {
-    color: ice-adjust-color($button-base-color,  -$button-pressed-color-inc);
-  }
-
-  &:focus {
-    // Makes the focus outline slightly less obstrusive
-    outline-offset: $button-focus-outline-offset;
-    // Make outline more appealing to the eye
-    outline-color: $border-input;
-  }
-
-  // Disabled state
-  &[disabled],
-  fieldset[disabled] & { // we may decide to change fieldset to a class later on
-    @include disabled-input();
-    color: ice-adjust-color($button-base-color,  $button-disabled-color-inc);
-  }
-
-  // If button is tied to a dropdown that's open,
-  // don't display outline, display hover color instead
-  // TODO: remove after dropdown refactor
-  .open &.dropdown-toggle:focus,
-  .open &[data-toggle='dropdown']:focus {
-    outline: none;
-    color: $button-icon-hover-color;
-  }
-}
-
-// Technically we don't allow buttons to be anything other than a button element,
-// however for file uploads we have to use the label element
-label[class^='button-'] {
-  line-height: $button-height;
-  min-width: min-content;
-}
 
 // Button types
 // -----------------------------------------------------------------------------
@@ -96,108 +23,26 @@ label[class^='button-'] {
 // Basic Button types
 // -------------------------
 
-// Plain button (that should always have an icon to indicate that it is a button)
-.button-text {
-  @extend %button;
+@import 'types/text';
+@import 'types/default';
+@import 'types/primary';
+@import 'types/danger';
+@import 'types/link';
+@import 'types/select';
+@import 'types/icon';
+
+// Misc
+
+// Technically we don't allow buttons to be anything other than a button element,
+// however for file uploads we have to use the label element
+label[class^='button-'] {
+  line-height: $button-height;
+  min-width: min-content;
 }
 
-// Default button - use in most cases
-.button-default {
-  @extend %button;
-  @include button-type($button-default-color, $button-default-bg-color, $button-default-border-color);
-}
-
-// Primary button - use for primary action in flow
-.button-primary {
-  @extend %button;
-  @include button-type($button-primary-color, $button-primary-bg-color, $button-primary-border-color);
-}
-
-// Danger button - use to warn user of negative action, such as delete
-.button-danger {
-  @extend %button;
-  @include button-type($button-danger-color, $button-danger-bg-color, $button-danger-border-color);
-}
-
-// Link button - a button that looks like a link
-.button-link {
-  @extend %button;
-  @include button-type($text-link, transparent, transparent);
-
-  &:not(:hover) {
-    text-decoration: underline;
-  }
-}
-
-// NOTE: this is new variant to replace the btn-dashed utility.
-// Since in all the uses we only have it on btn-default, it makes sense to extend
-// that style and tie them permanently
-// This may be removed later if we decide we don't need it
-.button-select {
-  @extend .button-default;
-  border-style: dashed;
-}
-
-
-// Icon Button
-// -----------------------
-// All this class does is set the colors for icons and evenly distribute the spacing
-
-.button-icon {
-  @extend %button;
-  color: $button-icon-color;
-  padding: 0;
-  width: $button-icon-size;
-  min-width: $button-icon-size;
-
-  &:hover,
-  &:active,
-  &.is-active,
-  &.active,
-  .open &.dropdown-toggle {
-    border-color: $button-icon-hover-border;
-  }
-
-  // Have to adjust the pressed background color for default button since
-  // its a bit too light
-  &:active,
-  &.is-active,
-  &.active,
-  .open &.dropdown-toggle {
-    background-color: ice-adjust-color($button-default-bg-color, -0.5);
-  }
-
-  // Sometimes the icon buttons will have images rather than font awesome icons,
-  // so we need to use opacity for the hover effect
-  img {
-    transition: opacity $button-icon-transition-duration ease-out;
-    opacity: $button-icon-img-opacity;
-    height: $button-icon-img-size;
-  }
-
-  &:hover img,
-  &.is-active img,
-  &.active img {
-    opacity: 1;
-  }
-
-}
-
-// Button with caret
+// Utilities
 // -----------------------------------------------------------------------------
-// A very common button pattern used for dropdowns, popovers, selects, color picker, etc.
-// TODO: better name?
-%popper-target-button {
-  // Layout content and caret
-  display: inline-flex;
-  align-items: center;
-
-  .button-caret {
-    padding: 0 $button-caret-spacing;
-    vertical-align: middle;
-  }
-}
-
+//
 
 // Groups of Buttons
 // -----------------------------------------------------------------------------
@@ -229,10 +74,6 @@ label[class^='button-'] {
     }
   }
 }
-
-// Utilities
-// -----------------------------------------------------------------------------
-//
 
 // Button Sizes
 // --------------------------------------------------

--- a/styles/onyx/elements/inputs/button/_mixins.scss
+++ b/styles/onyx/elements/inputs/button/_mixins.scss
@@ -13,6 +13,7 @@
   color: inherit;
   font: inherit;
   line-height: 1;
+  cursor: pointer;
 
   &:active,
   &.is-active {

--- a/styles/onyx/elements/inputs/button/_placeholders.scss
+++ b/styles/onyx/elements/inputs/button/_placeholders.scss
@@ -1,0 +1,79 @@
+// Button placeholder used to create button types
+%button {
+  @include reset-button();
+  user-select: none;
+  touch-action: manipulation;
+
+  // Text formatting
+  color: $button-base-color;
+  font-family: $button-font-family;
+  font-size: $button-font-size;
+  font-weight: $button-font-weight;
+  text-align: center;
+  white-space: nowrap;
+
+  // Buttons now have a specific height for enforced uniformity
+  height: $button-height;
+  vertical-align: middle;
+  min-width: $button-min-width;
+  padding-left: $button-spacing-horizontal;
+  padding-right: $button-spacing-horizontal;
+
+  // Border placeholder maintains consistent spacing around all buttons with or without borders
+  border: $button-border-width solid transparent;
+  border-radius: $button-border-radius;
+
+  transition: background-color $button-transition-speed ease-in-out, border-color $button-transition-speed ease-in-out;
+
+  // Hover state
+  &:hover {
+    color: ice-adjust-color($button-base-color, $button-hover-color-inc);
+  }
+
+  // Active/Pressed state
+  &:active,
+  &.is-active,
+  &.active, // TODO: see if we can get ember to use is-active instead
+  .open &.dropdown-toggle { // TODO: remove dropdown-toggle after dropdown refactor {
+    color: ice-adjust-color($button-base-color,  -$button-pressed-color-inc);
+  }
+
+  &:focus {
+    // Makes the focus outline slightly less obstrusive
+    outline-offset: $button-focus-outline-offset;
+    // Make outline more appealing to the eye
+    outline-color: $border-input;
+  }
+
+  // Disabled state
+  &[disabled],
+  fieldset[disabled] & { // we may decide to change fieldset to a class later on
+    @include disabled-input();
+    color: ice-adjust-color($button-base-color,  $button-disabled-color-inc);
+  }
+
+  // If button is tied to a dropdown that's open,
+  // don't display outline, display hover color instead
+  // TODO: remove after dropdown refactor
+  .open &.dropdown-toggle:focus,
+  .open &[data-toggle='dropdown']:focus {
+    outline: none;
+    color: $button-icon-hover-color;
+  }
+}
+
+
+// Button with caret
+// -----------------------------------------------------------------------------
+// A very common button pattern used for dropdowns, popovers, selects, color picker, etc.
+// TODO: better name?
+%popper-target-button {
+  // Layout content and caret
+  display: inline-flex;
+  align-items: center;
+
+  .button-caret {
+    padding: 0 $button-caret-spacing;
+    vertical-align: middle;
+  }
+}

--- a/styles/onyx/elements/inputs/button/types/_danger.scss
+++ b/styles/onyx/elements/inputs/button/types/_danger.scss
@@ -1,0 +1,5 @@
+// Danger button - use to warn user of negative action, such as delete
+.button-danger {
+  @extend %button;
+  @include button-type($button-danger-color, $button-danger-bg-color, $button-danger-border-color);
+}

--- a/styles/onyx/elements/inputs/button/types/_default.scss
+++ b/styles/onyx/elements/inputs/button/types/_default.scss
@@ -1,0 +1,5 @@
+// Default button - use in most cases
+.button-default {
+  @extend %button;
+  @include button-type($button-default-color, $button-default-bg-color, $button-default-border-color);
+}

--- a/styles/onyx/elements/inputs/button/types/_icon.scss
+++ b/styles/onyx/elements/inputs/button/types/_icon.scss
@@ -1,0 +1,42 @@
+// Icon Button
+// -----------------------
+// All this class does is set the colors for icons and evenly distribute the spacing
+
+.button-icon {
+  @extend %button;
+  color: $button-icon-color;
+  padding: 0;
+  width: $button-icon-size;
+  min-width: $button-icon-size;
+
+  &:hover,
+  &:active,
+  &.is-active,
+  &.active,
+  .open &.dropdown-toggle {
+    border-color: $button-icon-hover-border;
+  }
+
+  // Have to adjust the pressed background color for default button since
+  // its a bit too light
+  &:active,
+  &.is-active,
+  &.active,
+  .open &.dropdown-toggle {
+    background-color: ice-adjust-color($button-default-bg-color, -0.5);
+  }
+
+  // Sometimes the icon buttons will have images rather than font awesome icons,
+  // so we need to use opacity for the hover effect
+  img {
+    transition: opacity $button-icon-transition-duration ease-out;
+    opacity: $button-icon-img-opacity;
+    height: $button-icon-img-size;
+  }
+
+  &:hover img,
+  &.is-active img,
+  &.active img {
+    opacity: 1;
+  }
+}

--- a/styles/onyx/elements/inputs/button/types/_link.scss
+++ b/styles/onyx/elements/inputs/button/types/_link.scss
@@ -1,0 +1,9 @@
+// Link button - a button that looks like a link
+.button-link {
+  @extend %button;
+  @include button-type($text-link, transparent, transparent);
+
+  &:not(:hover) {
+    text-decoration: underline;
+  }
+}

--- a/styles/onyx/elements/inputs/button/types/_primary.scss
+++ b/styles/onyx/elements/inputs/button/types/_primary.scss
@@ -1,0 +1,5 @@
+// Primary button - use for primary action in flow
+.button-primary {
+  @extend %button;
+  @include button-type($button-primary-color, $button-primary-bg-color, $button-primary-border-color);
+}

--- a/styles/onyx/elements/inputs/button/types/_select.scss
+++ b/styles/onyx/elements/inputs/button/types/_select.scss
@@ -1,0 +1,8 @@
+// NOTE: this is new variant to replace the btn-dashed utility.
+// Since in all the uses we only have it on btn-default, it makes sense to extend
+// that style and tie them permanently
+// This may be removed later if we decide we don't need it
+.button-select {
+  @extend .button-default;
+  border-style: dashed;
+}

--- a/styles/onyx/elements/inputs/button/types/_text.scss
+++ b/styles/onyx/elements/inputs/button/types/_text.scss
@@ -1,0 +1,4 @@
+// Plain button (that should always have an icon to indicate that it is a button)
+.button-text {
+  @extend %button;
+}


### PR DESCRIPTION
In Portal we are running into an issue with the fact that we only want to use a couple Onyx button types, yet with the old way we are forced to include all button types. This is a problem because we'd like to reuse the naming for some of the other button types, but they are different styles. This means lots of hacking over the Onyx CSS, resulting in not just more confusing CSS to manage, but  alot more compiled output for portal.

This PR pulls out button types into individual files, then those are imported back to core. Did the same for placeholders (bc we should have had those separate anyway, whoops). The core file after this change should have the same output as before, maybe a little order shuffling but thats fine. I tested that all of the buttons still look correct. That way existing code bases pointing to this file do not get broken buttons.

The only _actual_ CSS change I made was to move the `cursor: pointer` over to the` button-reset` mixin, not sure why I didn't have it there in the first place bc all buttons need that.

I'm aware that a possible result of this PR is to now wonder, should we do this for EVERY component now, and split up every single type/modifier class to its own file?  At this point I wouldn't waste time going back and refactoring whats already in style-toolbox, and just wait till the need arises. For new UI, we should evaluate it per component.

@Addepar/design @Addepar/fire 