### PR TITLE
add editable-table style

### DIFF
--- a/styles/onyx/components/table/_core.scss
+++ b/styles/onyx/components/table/_core.scss
@@ -165,6 +165,17 @@
       }
     }
   }
+
+  th,
+  td {
+    &.text-align-center {
+      text-align: center;
+    }
+
+    &.text-align-right {
+      text-align: right;
+    }
+  }
 }
 
 %ember-table {

--- a/styles/onyx/components/table/_editable-table.scss
+++ b/styles/onyx/components/table/_editable-table.scss
@@ -1,0 +1,71 @@
+@import './core';
+
+// This table uses the same core styles as our basic table,
+// but also has additional styles for usability as an editable table.
+.editable-table {
+  @extend %ember-table;
+
+  // There is a bizarre bug with position sticky that causes the table header cells
+  // to lose their border rendering when scrolled. This visually adds it back.
+  border-top: $table-border-style;
+  // The occluded-content placeholder is hiding the bottom border
+  // of the last row, this visually adds it back
+  border-bottom: $table-border-style;
+
+  // So scrollbar doesn't shift the table size and cause horizontal scrollbar.
+  // We just need to make sure the cells have enough padding to not get covered.
+  overflow: overlay;
+  // To match thinner looking scrollbar in design mock
+  // TODO: eventually address table scrollbars as a whole
+  &::-webkit-scrollbar {
+    width: $editable-table-scrollbar-width;
+  }
+
+  table {
+    // Fill space no matter how many columns
+    width: 100%;
+    // Try not to have horizontal scrollbar
+    max-width: 100%;
+  }
+
+  // Unique header style for this table
+  th {
+    background-color: $editable-table-header-bg-color;
+    box-shadow: $editable-table-header-box-shadow;
+  }
+
+  td,
+  th {
+    // All cells need border, "Excel" style
+    border: $table-border-style;
+    padding-left: $editable-table-cell-padding;
+    padding-right: $editable-table-cell-padding;
+    // for the position abs input inside
+    position: relative;
+  }
+
+  // (overwriting high specificity from core table...)
+  thead tr:first-child > th {
+    // As mentioned, position sticky bug causes border to disappear on scroll
+    // so we added it to the top of the container div.
+    // We remove the top border here bc when not scrolled, it doubles up with that wrapper border.
+    border-top: none;
+  }
+
+  td .ember-text-field {
+    // Design wants the input to fill the cell
+    @include fill-container();
+    border: $editable-table-input-active-border;
+    // Needed or the input stretches outside of the cell
+    max-width: 100%;
+    // Match padding of table cell
+    padding: $table-cell-padding ($editable-table-cell-padding - $editable-table-input-active-border-width);
+    // Match the text alignment of the cell
+    text-align: inherit;
+  }
+
+  // Highlight row on hover
+  .et-tr:hover td {
+    background-color: $table-row-hover-color;
+  }
+}

--- a/styles/onyx/components/table/_variables.scss
+++ b/styles/onyx/components/table/_variables.scss
@@ -41,4 +41,13 @@ $et-indent-amount: $spacing-double;
 $et-selectable-row-hover-background: $background-hover;
 $et-selectable-row-selected-background: $background-hover-active;
 
-
+// Editable Table
+// -----------------------------------------------------------------------------
+$editable-table-header-bg-color: $background-extra-light;
+// TODO: Refer back to core-variables when shadow section is no longer broken
+$editable-table-header-box-shadow: 4px 2px 8px 0px rgba(0, 0, 0, 0.1);
+$editable-table-cell-padding: $spacing-default;
+// To match thinner looking scrollbar in design mock
+$editable-table-scrollbar-width: $spacing-default;
+$editable-table-input-active-border-width: 2px;
+$editable-table-input-active-border: $editable-table-input-active-border-width solid $brand-blue-gray;

--- a/styles/onyx/elements/table/_variables.scss
+++ b/styles/onyx/elements/table/_variables.scss
@@ -8,6 +8,7 @@ $table-text-color: $text-dark;
 
 $table-border-style: $border-item-style;
 $table-cell-background: $background-white;
+$table-row-hover-color: $background-hover;
 
 $table-cell-padding: $spacing-small;
 $table-cell-overflow: hidden;


### PR DESCRIPTION
Editable table is being replaced with ET2 in Iverson right now. The old styles for the old table do not play well with new table. So I added the new ET2 version here.

@thisisangelng 

![screen shot 2018-08-22 at 4 06 40 pm](https://user-images.githubusercontent.com/12617682/44495881-a4e15900-a626-11e8-8c88-490f457bbcdc.png)
![screen shot 2018-08-22 at 4 06 56 pm](https://user-images.githubusercontent.com/12617682/44495882-a579ef80-a626-11e8-8b37-e3fd71a93399.png)
![screen shot 2018-08-22 at 4 07 04 pm](https://user-images.githubusercontent.com/12617682/44495883-a579ef80-a626-11e8-8ce4-e9b70e91ff1c.png)
