### PR TITLE
fix onyx table imports to not include .table css

### DIFF
--- a/styles/onyx/components/table/_core.scss
+++ b/styles/onyx/components/table/_core.scss
@@ -1,4 +1,5 @@
-@import '../../elements/table/index';
+@import '../../elements/table/core';
+@import '../../elements/table/variables';
 @import '../../elements/inputs/checkbox/checkbox-core';
 @import '../../elements/inputs/checkbox/collapse-core';
 


### PR DESCRIPTION
Redo imports so that .table is not outputted in the CSS, was causing chaos in Iverson

@billylittlefield 